### PR TITLE
Fix typo CHANGELOG.md

### DIFF
--- a/crates/precompile/CHANGELOG.md
+++ b/crates/precompile/CHANGELOG.md
@@ -262,7 +262,7 @@ Promoting it to stable version, and i dont expect for precompiles to change in a
 # v0.4.0
 date: 20.1.2022
 
-* Added feature for k256 lib. We now have choise to use bitcoin c lib and k256 for ecrecovery.
+* Added feature for k256 lib. We now have choice to use bitcoin c lib and k256 for ecrecovery.
 
 # v0.3.0
 


### PR DESCRIPTION
# Pull Request Title
**Fix typo in CHANGELOG.md**

## Description
This PR fixes a typo in the `CHANGELOG.md` file within the `crates/precompile` directory. The word "choise" has been corrected to "choice".

## Changes
- **File:** `crates/precompile/CHANGELOG.md`
- **Line:** 262
- **Change:** Replaced "choise" with "choice"

**Thank you for reviewing my pull request!**