### PR TITLE
docs: fix typos

### DIFF
--- a/crates/interpreter/src/interpreter/analysis.rs
+++ b/crates/interpreter/src/interpreter/analysis.rs
@@ -431,7 +431,7 @@ impl fmt::Display for EofValidationError {
             Self::CodeSectionNotAccessed => "Code section was not accessed",
             Self::InvalidTypesSection => "Invalid types section",
             Self::InvalidFirstTypesSection => "Invalid first types section",
-            Self::MaxStackMismatch => "Max stack element mismatchs",
+            Self::MaxStackMismatch => "Max stack element mismatches",
             Self::NoCodeSections => "No code sections",
             Self::SubContainerCalledInTwoModes => "Sub container called in two modes",
             Self::SubContainerNotAccessed => "Sub container not accessed",

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -277,7 +277,7 @@ impl Stack {
         unsafe {
             // NOTE: `ptr::swap_nonoverlapping` is more efficient than `slice::swap` or `ptr::swap`
             // because it operates under the assumption that the pointers do not overlap,
-            // eliminating an intemediate copy,
+            // eliminating an intermediate copy,
             // which is a condition we know to be true in this context.
             let top = self.data.as_mut_ptr().add(len - 1);
             core::ptr::swap_nonoverlapping(top.sub(n), top.sub(n_m_index), 1);

--- a/crates/interpreter/src/opcode.rs
+++ b/crates/interpreter/src/opcode.rs
@@ -818,7 +818,7 @@ mod tests {
             assert_eq!(
                 opcode.map(|opcode| opcode.terminating).unwrap_or_default(),
                 opcodes[i],
-                "Opcode {:?} terminating chack failed.",
+                "Opcode {:?} terminating check failed.",
                 opcode
             );
         }

--- a/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate/eofcreate_in_initcode.json
+++ b/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate/eofcreate_in_initcode.json
@@ -58,7 +58,7 @@
             "hash": "0xcf58b74259cd73e0b114accb676ada0a6d9dd876cc461517aa8b75ce5fcf2779",
             "comment": "`execution-spec-tests` generated test",
             "filling-transition-tool": "evmone-t8n 0.12.0-6+commit.2d20cc63.dirty",
-            "description": "Test function documentation:\n\n    Verifies an EOFCREATE occuring within initcode creates that contract",
+            "description": "Test function documentation:\n\n    Verifies an EOFCREATE occurring within initcode creates that contract",
             "url": "https://github.com/ethereum/execution-spec-tests/blob/60b2036d3a8090e36595948846578af102666e65/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py#L277",
             "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7620.md",
             "reference-spec-version": "52ddbcdddcf72dd72427c319f2beddeb468e1737"

--- a/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate/eofcreate_in_initcode_reverts.json
+++ b/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate/eofcreate_in_initcode_reverts.json
@@ -60,7 +60,7 @@
             "hash": "0x19c114780894eb7bd2ec778dbc3d8e9bf465e2946616f0671a2a6bb252d4ef98",
             "comment": "`execution-spec-tests` generated test",
             "filling-transition-tool": "evmone-t8n 0.12.0-6+commit.2d20cc63.dirty",
-            "description": "Test function documentation:\n\n    Verifies an EOFCREATE occuring in an initcode is rolled back when the initcode reverts",
+            "description": "Test function documentation:\n\n    Verifies an EOFCREATE occurring in an initcode is rolled back when the initcode reverts",
             "url": "https://github.com/ethereum/execution-spec-tests/blob/60b2036d3a8090e36595948846578af102666e65/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py#L333",
             "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7620.md",
             "reference-spec-version": "52ddbcdddcf72dd72427c319f2beddeb468e1737"

--- a/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_gas_memory_expansion.json
+++ b/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_gas_memory_expansion.json
@@ -61,7 +61,7 @@
             "hash": "0x6273b228802ee2e20a421f47de153852176e4b783b437034b745523ba53bc125",
             "comment": "`execution-spec-tests` generated test",
             "filling-transition-tool": "evmone-t8n 0.12.0-6+commit.2d20cc63.dirty",
-            "description": "Test function documentation:\n\n    Excercises an EOFCREATE when the memory for auxdata has not been expanded but is requested",
+            "description": "Test function documentation:\n\n    Exercises an EOFCREATE when the memory for auxdata has not been expanded but is requested",
             "url": "https://github.com/ethereum/execution-spec-tests/blob/60b2036d3a8090e36595948846578af102666e65/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py#L461",
             "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7620.md",
             "reference-spec-version": "52ddbcdddcf72dd72427c319f2beddeb468e1737"

--- a/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_initcode_gas.json
+++ b/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_initcode_gas.json
@@ -61,7 +61,7 @@
             "hash": "0xf0f1131608a6fc46c479499429684ee280c6c63f8eb64f778b46bdf7f286ff58",
             "comment": "`execution-spec-tests` generated test",
             "filling-transition-tool": "evmone-t8n 0.12.0-6+commit.2d20cc63.dirty",
-            "description": "Test function documentation:\n\n    Excercises an EOFCREATE when there is not enough gas for the initcode charge",
+            "description": "Test function documentation:\n\n    Exercises an EOFCREATE when there is not enough gas for the initcode charge",
             "url": "https://github.com/ethereum/execution-spec-tests/blob/60b2036d3a8090e36595948846578af102666e65/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py#L399",
             "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7620.md",
             "reference-spec-version": "52ddbcdddcf72dd72427c319f2beddeb468e1737"

--- a/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_returncontract_auxdata_gas.json
+++ b/tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_returncontract_auxdata_gas.json
@@ -61,7 +61,7 @@
             "hash": "0x78e2f5f88e4815c5e66f3e2beb24e9d96546f7976869a010c124c54d3ecf0160",
             "comment": "`execution-spec-tests` generated test",
             "filling-transition-tool": "evmone-t8n 0.12.0-6+commit.2d20cc63.dirty",
-            "description": "Test function documentation:\n\n    Excercises an EOFCREATE when there is not enough gas for the initcode charge",
+            "description": "Test function documentation:\n\n    Exercises an EOFCREATE when there is not enough gas for the initcode charge",
             "url": "https://github.com/ethereum/execution-spec-tests/blob/60b2036d3a8090e36595948846578af102666e65/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py#L521",
             "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7620.md",
             "reference-spec-version": "52ddbcdddcf72dd72427c319f2beddeb468e1737"


### PR DESCRIPTION
# Summery

Fix typos in the repository

# Changes

1. /crates/interpreter/src/opcode.rs:821: chack => check
2. /crates/interpreter/src/interpreter/analysis.rs:434: mismatchs => mismatches
3. /crates/interpreter/src/interpreter/stack.rs:280: intemediate => intermediate
4. /tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate/eofcreate_in_initcode.json:61: occuring => occurring
5. /tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate/eofcreate_in_initcode_reverts.json:63: occuring => occurring
6. /tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_gas_memory_expansion.json:64: Excercises => Exercises
7. /tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_initcode_gas.json:64: Excercises => Exercises
8. /tests/eof_suite/eest/state_tests/prague/eip7692_eof_v1/eip7620_eof_create/eofcreate_failures/insufficient_returncontract_auxdata_gas.json:64: Excercises => Exercises
