### PR TITLE
fix: turn off `openvm-k256` for patching

### DIFF
--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -146,7 +146,8 @@ bn = ["dep:bn"]
 # Enable openvm accelerated implementation
 openvm-bn = ["dep:openvm", "openvm-ecc-guest", "openvm-pairing/bn254"]
 
-openvm = ["dep:openvm", "openvm-k256", "openvm-bn", "openvm-sha2", "openvm-kzg"]
+# We do NOT include `openvm-k256` because it will cause a conflict when patching k256
+openvm = ["dep:openvm", "openvm-bn", "openvm-sha2", "openvm-kzg"]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
Cannot import `openvm-k256` and `k256` together if you later patch `k256` with `openvm-k256`, so for now we don't enable `openvm-k256` by default. It only leads to a small performance diff, so we may just delete the `openvm-k256` feature eventually.